### PR TITLE
Add `affinity` customization

### DIFF
--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -61,6 +61,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## Kafka JMX Settings
 ## ref: https://docs.confluent.io/current/kafka/monitoring.html

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -140,3 +140,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -65,6 +65,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## Kafka Connect JMX Settings
 ## ref: https://kafka.apache.org/documentation/#connect_monitoring

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -110,3 +110,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -46,6 +46,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Kafka REST configuration options
 ## ref: https://docs.confluent.io/current/kafka-rest/docs/config.html
 configurationOverrides:

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       {{- end }}
     spec:
       affinity:
+      {{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -55,6 +58,7 @@ spec:
                     values:
                     - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       containers:
       {{- if .Values.prometheus.jmx.enabled }}
       - name: prometheus-jmx-exporter

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -108,6 +108,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## Kafka JMX Settings
 ## ref: https://docs.confluent.io/current/kafka/monitoring.html

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -121,3 +121,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -46,6 +46,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## JMX Settings
 ## ref: https://docs.confluent.io/current/ksql/docs/operations.html

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -118,3 +118,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -65,6 +65,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## Schema Registry JMX Settings
 ## ref: https://docs.confluent.io/current/schema-registry/docs/monitoring.html

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       {{- end }}
     spec:
       affinity:
+      {{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -55,6 +58,7 @@ spec:
                     values:
                     - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       containers:
       {{- if .Values.prometheus.jmx.enabled }}
       - name: prometheus-jmx-exporter

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -103,6 +103,10 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod scheduling constraints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Monitoring
 ## Zookeeper JMX Settings
 ## ref: https://docs.confluent.io/current/installation/docker/docs/operations/monitoring.html


### PR DESCRIPTION
For charts that have existing `affinity` hard-coded configs
defined, add support for overriding the hard-coded values.

For charts that lack `affinity` config entirely, add
the support for injecting custom affinity values.
